### PR TITLE
Add a parent component for the wizard sequence

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 node_modules/
 dist/
+.yarn

--- a/src/react/App.tsx
+++ b/src/react/App.tsx
@@ -3,9 +3,7 @@ import { HashRouter, Route, Switch } from "react-router-dom";
 import Home from "./pages/Home";
 import React from "react";
 import styled from "styled-components";
-import MnemonicGenerationWizard from "./pages/MnemonicGenerationWizard";
-import MnemonicImport from "./pages/MnemonicImport";
-import KeyGenerationWizard from "./pages/KeyGenerationWizard";
+import Wizard from "./pages/Wizard";
 import { CssBaseline, ThemeProvider } from "@material-ui/core";
 import theme from "./theme";
 import 'typeface-roboto';
@@ -25,9 +23,7 @@ const App = () => {
         <Container>
           <Switch>
             <Route exact path="/" component={Home} />
-            <Route exact path="/mnemonicgeneration" component={MnemonicGenerationWizard} />
-            <Route exact path="/mnemonicimport" component={MnemonicImport} />
-            <Route exact path="/keygeneration" component={KeyGenerationWizard} />
+            <Route path="/wizard" component={Wizard} />
           </Switch>
         </Container>
       </HashRouter>

--- a/src/react/components/MnemonicGenerationFlow/0-GenerateMnemonic.tsx
+++ b/src/react/components/MnemonicGenerationFlow/0-GenerateMnemonic.tsx
@@ -2,8 +2,7 @@ import { Grid, Typography } from '@material-ui/core';
 import React, { Dispatch, SetStateAction } from 'react';
 
 type GenerateMnemonicProps = {
-  step: number,
-  setMnemonic: Dispatch<SetStateAction<string>>,
+  step: number
 }
 
 const GenerateMnemonic = (props: GenerateMnemonicProps) => {

--- a/src/react/pages/Home.tsx
+++ b/src/react/pages/Home.tsx
@@ -121,7 +121,7 @@ const Home = () => {
       handleOpenNetworkModal();
     } else {
       const location = {
-        pathname: "/mnemonicgeneration",
+        pathname: "/wizard/mnemonicgeneration",
         state: {
           network: networkSelected,
         },
@@ -138,7 +138,7 @@ const Home = () => {
       handleOpenNetworkModal();
     } else {
       const location = {
-        pathname: "/mnemonicimport",
+        pathname: "/wizard/mnemonicimport",
         state: {
           network: networkSelected,
         },

--- a/src/react/pages/KeyGenerationWizard.tsx
+++ b/src/react/pages/KeyGenerationWizard.tsx
@@ -23,15 +23,18 @@ const ContentGrid = styled(Grid)`
   height: 450px;
 `;
 
+type Props = {
+  network: string
+}
+
 type IncomingState = {
-  network: string,
   mnemonic: string,
   index: number | null,
 }
 
-type Props = RouteComponentProps<{}, any, IncomingState>;
+type RouteProps = RouteComponentProps<{}, any, IncomingState>;
 
-const KeyGenerationWizard = (props: Props) => {
+const KeyGenerationWizard = (props: Props & RouteProps) => {
   const [step, setStep] = useState(0);
   const [index, setIndex] = useState(props.location.state.index);
   const [numberOfKeys, setNumberOfKeys] = useState(0);
@@ -213,7 +216,7 @@ const KeyGenerationWizard = (props: Props) => {
     if (os == "Linux") {
       console.log("On linux, generating keys.");
       
-      generateKeys(props.location.state.mnemonic, index!, numberOfKeys, props.location.state.network.toLowerCase(), password, "", folderPath);
+      generateKeys(props.location.state.mnemonic, index!, numberOfKeys, props.network.toLowerCase(), password, "", folderPath);
 
     } else {
       console.log("Pretended to generate keys since not on linux.");
@@ -230,7 +233,7 @@ const KeyGenerationWizard = (props: Props) => {
         <Grid item xs={10}/>
         <Grid item xs={2}>
           <Typography variant="caption" style={{color: "gray"}}>
-            Network: {props.location.state.network}
+            Network: {props.network}
           </Typography>
         </Grid>
       </Grid>

--- a/src/react/pages/KeyGenerationWizard.tsx
+++ b/src/react/pages/KeyGenerationWizard.tsx
@@ -24,11 +24,11 @@ const ContentGrid = styled(Grid)`
 `;
 
 type Props = {
-  network: string
+  network: string,
+  mnemonic: string
 }
 
 type IncomingState = {
-  mnemonic: string,
   index: number | null,
 }
 
@@ -216,7 +216,7 @@ const KeyGenerationWizard = (props: Props & RouteProps) => {
     if (os == "Linux") {
       console.log("On linux, generating keys.");
       
-      generateKeys(props.location.state.mnemonic, index!, numberOfKeys, props.network.toLowerCase(), password, "", folderPath);
+      generateKeys(props.mnemonic, index!, numberOfKeys, props.network.toLowerCase(), password, "", folderPath);
 
     } else {
       console.log("Pretended to generate keys since not on linux.");

--- a/src/react/pages/MnemonicGenerationWizard.tsx
+++ b/src/react/pages/MnemonicGenerationWizard.tsx
@@ -137,6 +137,7 @@ const MnemonicGenerationWizard = (props: Props & RouteProps) => {
     const location = {
       pathname: '/wizard/keygeneration',
       state: {
+        network: props.network,
         index: 0,
       }
     }

--- a/src/react/pages/MnemonicGenerationWizard.tsx
+++ b/src/react/pages/MnemonicGenerationWizard.tsx
@@ -19,13 +19,13 @@ const ContentGrid = styled(Grid)`
   height: 450px;
 `;
 
-type IncomingState = {
-  network: string,
+type Props = {
+  network: string
 }
 
-type Props = RouteComponentProps<{}, any, IncomingState>;
+type RouteProps = RouteComponentProps<{}, any, {}>;
 
-const MnemonicGenerationWizard = (props: Props) => {
+const MnemonicGenerationWizard = (props: Props & RouteProps) => {
   const [step, setStep] = useState(0);
   const [mnemonic, setMnemonic] = useState("");
   const [verifyMnemonic, setVerifyMnemonic] = useState("");
@@ -134,9 +134,8 @@ const MnemonicGenerationWizard = (props: Props) => {
 
   const toKeyGenerationWizard = () => {
     const location = {
-      pathname: '/keygeneration',
+      pathname: '/wizard/keygeneration',
       state: {
-        network: props.location.state.network,
         mnemonic: mnemonic,
         index: 0,
       }
@@ -160,7 +159,7 @@ const MnemonicGenerationWizard = (props: Props) => {
         <Grid item xs={10}/>
         <Grid item xs={2}>
           <Typography variant="caption" style={{color: "gray"}}>
-            Network: {props.location.state.network}
+            Network: {props.network}
           </Typography>
         </Grid>
       </Grid>

--- a/src/react/pages/MnemonicGenerationWizard.tsx
+++ b/src/react/pages/MnemonicGenerationWizard.tsx
@@ -1,5 +1,5 @@
 import { Button, Grid, Typography } from '@material-ui/core';
-import React, { useState } from 'react';
+import React, { useState, Dispatch, SetStateAction } from 'react';
 import { useHistory, withRouter } from 'react-router';
 import { RouteComponentProps } from 'react-router-dom';
 import styled from 'styled-components';
@@ -20,14 +20,15 @@ const ContentGrid = styled(Grid)`
 `;
 
 type Props = {
-  network: string
+  network: string,
+  mnemonic: string,
+  setMnemonic: Dispatch<SetStateAction<string>>
 }
 
 type RouteProps = RouteComponentProps<{}, any, {}>;
 
 const MnemonicGenerationWizard = (props: Props & RouteProps) => {
   const [step, setStep] = useState(0);
-  const [mnemonic, setMnemonic] = useState("");
   const [verifyMnemonic, setVerifyMnemonic] = useState("");
   const [mnemonicValidationError, setMnemonicValidationError] = useState(false);
 
@@ -53,7 +54,7 @@ const MnemonicGenerationWizard = (props: Props & RouteProps) => {
         break;
       }
       case 1: {
-        setMnemonic("");
+        props.setMnemonic("");
         setStep(step - 1);
         break;
       }
@@ -111,7 +112,7 @@ const MnemonicGenerationWizard = (props: Props & RouteProps) => {
 
       // VerifyMnemonic
       case 3: {
-        if (mnemonic.localeCompare(verifyMnemonic) == 0) {
+        if (props.mnemonic.localeCompare(verifyMnemonic) == 0) {
           setMnemonicValidationError(false);
           toKeyGenerationWizard();
         } else {
@@ -136,7 +137,6 @@ const MnemonicGenerationWizard = (props: Props & RouteProps) => {
     const location = {
       pathname: '/wizard/keygeneration',
       state: {
-        mnemonic: mnemonic,
         index: 0,
       }
     }
@@ -146,9 +146,9 @@ const MnemonicGenerationWizard = (props: Props & RouteProps) => {
 
   const uiCreateMnemonic = () => {
     if (uname() == "Linux") {
-      setMnemonic(createMnemonic('english'));
+      props.setMnemonic(createMnemonic('english'));
     } else {
-      setMnemonic("one two three four five six seven eight nine ten eleven twelve one two three four five six seven eight nine ten eleven twelve");
+      props.setMnemonic("one two three four five six seven eight nine ten eleven twelve one two three four five six seven eight nine ten eleven twelve");
     }
   }
 
@@ -172,8 +172,8 @@ const MnemonicGenerationWizard = (props: Props & RouteProps) => {
       </Grid>
       <ContentGrid item container>
         <Grid item xs={12}>
-          <GenerateMnemonic step={step} setMnemonic={setMnemonic} />
-          <ShowMnemonic step={step} mnemonic={mnemonic} />
+          <GenerateMnemonic step={step} />
+          <ShowMnemonic step={step} mnemonic={props.mnemonic} />
           <VerifyMnemonic step={step} setVerifyMnemonic={setVerifyMnemonic} error={mnemonicValidationError} />
         </Grid>
       </ContentGrid>

--- a/src/react/pages/MnemonicImport.tsx
+++ b/src/react/pages/MnemonicImport.tsx
@@ -14,13 +14,13 @@ const ContentGrid = styled(Grid)`
   height: 450px;
 `;
 
-type IncomingState = {
-  network: string,
+type Props = {
+  network: string
 }
 
-type Props = RouteComponentProps<{}, any, IncomingState>;
+type RouteProps = RouteComponentProps<{}, any, {}>;
 
-const MnemonicImport = (props: Props) => {
+const MnemonicImport = (props: Props & RouteProps) => {
   const [mnemonic, setMnemonic] = useState("");
   const [mnemonicError, setMnemonicError] = useState(false);
 
@@ -43,9 +43,8 @@ const MnemonicImport = (props: Props) => {
       setMnemonicError(false);
 
       const location = {
-        pathname: '/keygeneration',
+        pathname: '/wizard/keygeneration',
         state: {
-          network: props.location.state.network,
           mnemonic: mnemonic,
           index: null,
         }
@@ -61,7 +60,7 @@ const MnemonicImport = (props: Props) => {
         <Grid item xs={10}/>
         <Grid item xs={2}>
           <Typography variant="caption" style={{color: "gray"}}>
-            Network: {props.location.state.network}
+            Network: {props.network}
           </Typography>
         </Grid>
       </Grid>

--- a/src/react/pages/MnemonicImport.tsx
+++ b/src/react/pages/MnemonicImport.tsx
@@ -1,5 +1,5 @@
 import { Button, Grid, TextField, Typography } from "@material-ui/core";
-import React, { useState } from "react";
+import React, { useState, Dispatch, SetStateAction } from "react";
 import { RouteComponentProps, useHistory, withRouter } from "react-router-dom";
 import styled from "styled-components";
 import { errors, MNEMONIC_LENGTH } from "../constants";
@@ -15,19 +15,20 @@ const ContentGrid = styled(Grid)`
 `;
 
 type Props = {
-  network: string
+  network: string,
+  mnemonic: string,
+  setMnemonic: Dispatch<SetStateAction<string>>
 }
 
 type RouteProps = RouteComponentProps<{}, any, {}>;
 
 const MnemonicImport = (props: Props & RouteProps) => {
-  const [mnemonic, setMnemonic] = useState("");
   const [mnemonicError, setMnemonicError] = useState(false);
 
   let history = useHistory();
 
   const updateInputMnemonic = (e: React.ChangeEvent<HTMLInputElement>) => {
-    setMnemonic(e.target.value);
+    props.setMnemonic(e.target.value);
   }
 
   const toHome = () => {
@@ -35,7 +36,7 @@ const MnemonicImport = (props: Props & RouteProps) => {
   }
 
   const toKeyGenerationWizard = () => {
-    const mnemonicArray = mnemonic.split(" ");
+    const mnemonicArray = props.mnemonic.split(" ");
 
     if (mnemonicArray.length != MNEMONIC_LENGTH) {
       setMnemonicError(true);
@@ -45,7 +46,6 @@ const MnemonicImport = (props: Props & RouteProps) => {
       const location = {
         pathname: '/wizard/keygeneration',
         state: {
-          mnemonic: mnemonic,
           index: null,
         }
       }

--- a/src/react/pages/MnemonicImport.tsx
+++ b/src/react/pages/MnemonicImport.tsx
@@ -46,6 +46,7 @@ const MnemonicImport = (props: Props & RouteProps) => {
       const location = {
         pathname: '/wizard/keygeneration',
         state: {
+          network: props.network,
           index: null,
         }
       }

--- a/src/react/pages/Wizard.tsx
+++ b/src/react/pages/Wizard.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useState } from 'react';
 import { Route, Switch, useRouteMatch, RouteComponentProps } from "react-router-dom";
 import MnemonicGenerationWizard from "./MnemonicGenerationWizard";
 import MnemonicImport from "./MnemonicImport";
@@ -12,6 +12,7 @@ type Props = RouteComponentProps<{}, any, IncomingState>;
 
 function Wizard (props: Props) {
   let { path } = useRouteMatch();
+  const [mnemonic, setMnemonic] = useState("");
   const { network } = props.location.state;
 
   return (
@@ -19,17 +20,17 @@ function Wizard (props: Props) {
       <Route
         exact
         path={`${path}/mnemonicgeneration`}
-        render={routeProps => <MnemonicGenerationWizard {...routeProps} network={network} />} 
+        render={routeProps => <MnemonicGenerationWizard {...{ ...routeProps, network, mnemonic, setMnemonic }} />} 
       />
       <Route
         exact
         path={`${path}/mnemonicimport`}
-        render={routeProps => <MnemonicImport {...routeProps} network={network} />}
+        render={routeProps => <MnemonicImport {...{ ...routeProps, network, mnemonic, setMnemonic }} />}
       />
       <Route
         exact
         path={`${path}/keygeneration`}
-        render={routeProps => <KeyGenerationWizard {...routeProps} network={network} />}
+        render={routeProps => <KeyGenerationWizard {...{ ...routeProps, network, mnemonic }} />}
       />
     </Switch>
   );

--- a/src/react/pages/Wizard.tsx
+++ b/src/react/pages/Wizard.tsx
@@ -1,0 +1,38 @@
+import React from 'react';
+import { Route, Switch, useRouteMatch, RouteComponentProps } from "react-router-dom";
+import MnemonicGenerationWizard from "./MnemonicGenerationWizard";
+import MnemonicImport from "./MnemonicImport";
+import KeyGenerationWizard from "./KeyGenerationWizard";
+
+type IncomingState = {
+  network: string,
+}
+
+type Props = RouteComponentProps<{}, any, IncomingState>;
+
+function Wizard (props: Props) {
+  let { path } = useRouteMatch();
+  const { network } = props.location.state;
+
+  return (
+    <Switch>
+      <Route
+        exact
+        path={`${path}/mnemonicgeneration`}
+        render={routeProps => <MnemonicGenerationWizard {...routeProps} network={network} />} 
+      />
+      <Route
+        exact
+        path={`${path}/mnemonicimport`}
+        render={routeProps => <MnemonicImport {...routeProps} network={network} />}
+      />
+      <Route
+        exact
+        path={`${path}/keygeneration`}
+        render={routeProps => <KeyGenerationWizard {...routeProps} network={network} />}
+      />
+    </Switch>
+  );
+}
+
+export default Wizard;


### PR DESCRIPTION
## Why
Adding a parent component is a prerequisite for the chosen design of issues #3 and #15 , the design being a wizard parent component for shared state and UI.  This is a is a transitional PR for the implementation of a Stepper component (#3), so design will change further as the Stepper is implemented.

## Changes
- Add a Wizard component at the `/wizard` route with nested routes `mnemonicimport`, `mnemonicgeneration`, and `keygeneration`.  I would like to rename this to KeyGenerationWizard if the current page-level component with that name is no longer a route and the component can be moved to the components folder.
- Move `mnemonic` state and setter up to wizard parent and pass to children as props.
- Pass `network` to wizard parent in route state and pass to children as a prop.
- Remove `setMnemonic` prop from `0-GenerateMnemonic` component
- Add `.yarn` to gitignore