### PR TITLE
Fix application name with proper spaces and uppercase letters

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,6 @@
 {
   "name": "wagyukeygen",
+  "productName": "Wagyu Key Gen",
   "version": "0.8.0",
   "description": "GUI key generation tool wrapping the deposit cli.",
   "main": "./build/electron/index.js",
@@ -52,7 +53,7 @@
   },
   "build": {
     "appId": "gg.wagyu.keygen",
-    "productName": "WagyuKeyGen",
+    "productName": "Wagyu Key Gen",
     "files": [
       "build/**/*",
       "package.json"

--- a/src/electron/index.ts
+++ b/src/electron/index.ts
@@ -1,5 +1,4 @@
 import { BrowserWindow, app, globalShortcut, ipcMain } from "electron";
-import { cwd } from 'process';
 import path from "path";
 
 import { accessSync, constants } from "fs";
@@ -21,10 +20,13 @@ app.on("ready", () => {
     iconPath = bundledIconPath;
   }
 
+  const title = `${app.getName()}`;
+
   const window = new BrowserWindow({
     width: 900,
     height: 720,
     icon: iconPath,
+    title: title,
 
     webPreferences: {
       nodeIntegration: true,

--- a/src/react/index.html
+++ b/src/react/index.html
@@ -1,7 +1,4 @@
 <html>
-  <head>
-    <title>Wagyu Key Gen</title>
-  </head>
   <body style="width:100%;height:100%;margin:0">
     <div id="app" style="width:100%;height:100%">
     </div>


### PR DESCRIPTION
It will now use the productName stored in the `package.json` file for naming where it matters: title, hover info, etc. In dev, it might show Electron, but it will show the correct name when started from a bundle.