### PR TITLE
Max keys 100000 in one generate

### DIFF
--- a/src/react/components/KeyConfigurationWizard.tsx
+++ b/src/react/components/KeyConfigurationWizard.tsx
@@ -100,7 +100,7 @@ const KeyConfigurationWizard: FC<Props> = (props): ReactElement => {
   const validateInputs = () => {
     let isError = false;
 
-    if (props.numberOfKeys < 1) {
+    if (props.numberOfKeys < 1 || props.numberOfKeys > 100000) {
       setNumberOfKeysError(true);
       isError = true;
     } else {

--- a/src/react/components/KeyGeneratioinFlow/0-KeyInputs.tsx
+++ b/src/react/components/KeyGeneratioinFlow/0-KeyInputs.tsx
@@ -68,7 +68,7 @@ const KeyInputs = (props: GenerateKeysProps) => {
               autoFocus
               value={props.numberOfKeys}
               onChange={updateNumberOfKeys}
-              InputProps={{ inputProps: { min: 1 } }}
+              InputProps={{ inputProps: { min: 1, max: 100000 } }}
               error={props.numberOfKeysError}
               helperText={ props.numberOfKeysError ? errors.NUMBER_OF_KEYS : ""}
             />

--- a/src/react/constants.ts
+++ b/src/react/constants.ts
@@ -3,7 +3,7 @@ import { StepKey } from './types';
 export const errors = {
 	MNEMONIC_FORMAT: "Invalid format. Your Secret Recovery Phrase should be a 24 word list.",
 	MNEMONICS_DONT_MATCH: "The Secret Recovery Phrase you entered does not match what was given to you. Please try again.",
-	NUMBER_OF_KEYS: "Please input number of keys.",
+	NUMBER_OF_KEYS: "Please input a number between 1 and 100,000.",
 	PASSWORD_STRENGTH: "Password must be at least 8 characters.",
 	PASSWORD_MATCH: "Passwords don't match.",
 	STARTING_INDEX: "Please input starting index.",


### PR DESCRIPTION
There was no specific max that I could find on the deposit cli other than int max, so I picked 100,000.  If a user needs to generate more, they can run it twice, the second time importing mnemonic and starting at the previous index.