### PR TITLE
Validate mnemonic using eth2deposit logic

### DIFF
--- a/src/react/commands/Eth2Deposit.ts
+++ b/src/react/commands/Eth2Deposit.ts
@@ -60,10 +60,10 @@ const createMnemonic = async (language: string): Promise<string> => {
   const escapedLanguage = escapeArgument(language);
 
   if (doesFileExist(BUNDLED_SFE_PATH)) {
-    cmd = BUNDLED_SFE_PATH + " " + CREATE_MNEMONIC_SUBCOMMAND + " " + BUNDLED_DIST_WORD_LIST_PATH + " --language " + escapedLanguage;
+    cmd = BUNDLED_SFE_PATH + " " + CREATE_MNEMONIC_SUBCOMMAND + " " + escapeArgument(BUNDLED_DIST_WORD_LIST_PATH) + " --language " + escapedLanguage;
     console.log('Calling bundled SFE for create mnemonic with cmd: ' + cmd);
   } else if (doesFileExist(SFE_PATH)) {
-      cmd = SFE_PATH + " " + CREATE_MNEMONIC_SUBCOMMAND + " " + DIST_WORD_LIST_PATH + " --language " + escapedLanguage;
+      cmd = SFE_PATH + " " + CREATE_MNEMONIC_SUBCOMMAND + " " + escapeArgument(DIST_WORD_LIST_PATH) + " --language " + escapedLanguage;
       console.log('Calling unbundled SFE for create mnemonic with cmd: ' + cmd);
   } else {
     if (!requireDepositPackages()) {
@@ -76,7 +76,7 @@ const createMnemonic = async (language: string): Promise<string> => {
   
     env.PYTHONPATH = expythonpath;
   
-    cmd = PYTHON_EXE + " " + ETH2DEPOSIT_PROXY_PATH + " " + CREATE_MNEMONIC_SUBCOMMAND + " " + WORD_LIST_PATH + " --language " + escapedLanguage;
+    cmd = PYTHON_EXE + " " + ETH2DEPOSIT_PROXY_PATH + " " + CREATE_MNEMONIC_SUBCOMMAND + " " + escapeArgument(WORD_LIST_PATH) + " --language " + escapedLanguage;
   }
 
   const { stdout, stderr } = await execProm(cmd, {env: env});
@@ -123,10 +123,10 @@ const generateKeys = async (
   const escapedFolder = escapeArgument(folder);
   
   if (doesFileExist(BUNDLED_SFE_PATH)) {
-    cmd = `${BUNDLED_SFE_PATH} ${GENERATE_KEYS_SUBCOMMAND} ${withdrawalAddress}${escapedMnemonic} ${index} ${count} ${escapedFolder} ${network.toLowerCase()} ${escapedPassword}`;
+    cmd = `${BUNDLED_SFE_PATH} ${GENERATE_KEYS_SUBCOMMAND} ${withdrawalAddress}${escapeArgument(BUNDLED_DIST_WORD_LIST_PATH)} ${escapedMnemonic} ${index} ${count} ${escapedFolder} ${network.toLowerCase()} ${escapedPassword}`;
     console.log('Calling bundled SFE for generate keys');
   } else if (doesFileExist(SFE_PATH)) {
-    cmd = `${SFE_PATH} ${GENERATE_KEYS_SUBCOMMAND} ${withdrawalAddress}${escapedMnemonic} ${index} ${count} ${escapedFolder} ${network.toLowerCase()} ${escapedPassword}`;
+    cmd = `${SFE_PATH} ${GENERATE_KEYS_SUBCOMMAND} ${withdrawalAddress}${escapeArgument(DIST_WORD_LIST_PATH)} ${escapedMnemonic} ${index} ${count} ${escapedFolder} ${network.toLowerCase()} ${escapedPassword}`;
     console.log('Calling SFE for generate keys');
   } else {
     if(!requireDepositPackages()) {
@@ -139,7 +139,7 @@ const generateKeys = async (
     
     env.PYTHONPATH = expythonpath;
 
-    cmd = `${PYTHON_EXE} ${ETH2DEPOSIT_PROXY_PATH} ${GENERATE_KEYS_SUBCOMMAND} ${withdrawalAddress}${escapedMnemonic} ${index} ${count} ${escapedFolder} ${network.toLowerCase()} ${escapedPassword}`;
+    cmd = `${PYTHON_EXE} ${ETH2DEPOSIT_PROXY_PATH} ${GENERATE_KEYS_SUBCOMMAND} ${withdrawalAddress}${escapeArgument(WORD_LIST_PATH)} ${escapedMnemonic} ${index} ${count} ${escapedFolder} ${network.toLowerCase()} ${escapedPassword}`;
   }
   
   await execProm(cmd, {env: env});

--- a/src/react/components/KeyGenerationWizard.tsx
+++ b/src/react/components/KeyGenerationWizard.tsx
@@ -130,11 +130,11 @@ const KeyGenerationWizard: FC<Props> = (props): ReactElement => {
       props.password,
       eth1_withdrawal_address,
       props.folderPath).then(() => {
-        props.onStepForward();
+      props.onStepForward();
     }).catch((error) => {
-      console.log(error);
+      setStep(0);
       setFolderError(true);
-      setFolderErrorMsg(error);
+      setFolderErrorMsg(error.stderr);
     })
 
   }

--- a/src/react/components/MnemonicImport.tsx
+++ b/src/react/components/MnemonicImport.tsx
@@ -1,6 +1,7 @@
 import { Grid, TextField, Typography } from "@material-ui/core";
 import React, { FC, ReactElement, useState, Dispatch, SetStateAction } from "react";
 import styled from "styled-components";
+import { validateMnemonic } from '../commands/Eth2Deposit';
 import { errors, MNEMONIC_LENGTH } from "../constants";
 import StepNavigation from './StepNavigation';
 
@@ -18,6 +19,7 @@ type Props = {
 
 const MnemonicImport: FC<Props> = (props): ReactElement => {
   const [mnemonicError, setMnemonicError] = useState(false);
+  const [mnemonicErrorMsg, setMnemonicErrorMsg] = useState("");
 
   const updateInputMnemonic = (e: React.ChangeEvent<HTMLInputElement>) => {
     props.setMnemonic(e.target.value);
@@ -26,13 +28,24 @@ const MnemonicImport: FC<Props> = (props): ReactElement => {
   const disableImport = !props.mnemonic;
 
   const onImport = () => {
+    setMnemonicError(false);
+    setMnemonicErrorMsg('');
+
     const mnemonicArray = props.mnemonic.split(" ");
 
     if (mnemonicArray.length != MNEMONIC_LENGTH) {
       setMnemonicError(true);
+      setMnemonicErrorMsg(errors.MNEMONIC_FORMAT);
     } else {
-      setMnemonicError(false);
-      props.onStepForward();
+
+      validateMnemonic(props.mnemonic).then(() => {
+        props.onStepForward();
+      }).catch((error) => {
+        const errorMsg = ('stderr' in error) ? error.stderr : error.message;
+        setMnemonicError(true);
+        setMnemonicErrorMsg(errorMsg);
+      })
+      
     }
   }
 
@@ -61,7 +74,7 @@ const MnemonicImport: FC<Props> = (props): ReactElement => {
             color="primary"
             autoFocus
             error={mnemonicError}
-            helperText={ mnemonicError ? errors.MNEMONIC_FORMAT : ""}
+            helperText={mnemonicErrorMsg}
             value={props.mnemonic}
             onChange={updateInputMnemonic}
             onKeyDown={handleKeyDown}/>

--- a/src/scripts/eth2deposit_proxy.py
+++ b/src/scripts/eth2deposit_proxy.py
@@ -83,6 +83,9 @@ def parse_create_mnemonic(args):
 def parse_generate_keys(args):
     generate_keys(args)
 
+def parse_validate_mnemonic(args):
+    validate_mnemonic(args.mnemonic, args.wordlist)
+
 def main():
     main_parser = argparse.ArgumentParser()
 
@@ -103,6 +106,11 @@ def main():
     generate_parser.add_argument("password", help="Password for the keystore files", type=str)
     generate_parser.add_argument("--eth1_withdrawal_address", help="Optional eth1 withdrawal address", type=str)
     generate_parser.set_defaults(func=parse_generate_keys)
+
+    validate_parser = subparsers.add_parser("validate_mnemonic")
+    validate_parser.add_argument("wordlist", help="Path to word list directory", type=str)
+    validate_parser.add_argument("mnemonic", help="Mnemonic", type=str)
+    validate_parser.set_defaults(func=parse_validate_mnemonic)
 
     args = main_parser.parse_args()
     if not args or 'func' not in args:


### PR DESCRIPTION
Expose the validation logic from the eth2-deposit-cli to our application. Call that logic when entering a mnemonic when generating from an existing mnemonic.

Depends on #88 
Closes #90