### PR TITLE
Disable buttons when open dialog is shown

### DIFF
--- a/src/electron/index.ts
+++ b/src/electron/index.ts
@@ -57,7 +57,7 @@ app.on("ready", () => {
    * Provides the renderer a way to call the dialog.showOpenDialog function using IPC.
    */
   ipcMain.handle('showOpenDialog', async (event, options) => {
-    return await dialog.showOpenDialog(window, <OpenDialogOptions> options);
+    return await dialog.showOpenDialog(<OpenDialogOptions> options);
   });
 
   // load a website to display

--- a/src/electron/index.ts
+++ b/src/electron/index.ts
@@ -53,6 +53,9 @@ app.on("ready", () => {
     app.quit()
   })
 
+  /**
+   * Provides the renderer a way to call the dialog.showOpenDialog function using IPC.
+   */
   ipcMain.handle('showOpenDialog', async (event, options) => {
     return await dialog.showOpenDialog(window, <OpenDialogOptions> options);
   });

--- a/src/electron/index.ts
+++ b/src/electron/index.ts
@@ -54,7 +54,7 @@ app.on("ready", () => {
   })
 
   ipcMain.handle('showOpenDialog', async (event, options) => {
-    return await dialog.showOpenDialog(<OpenDialogOptions> options);
+    return await dialog.showOpenDialog(window, <OpenDialogOptions> options);
   });
 
   // load a website to display

--- a/src/react/components/KeyGeneratioinFlow/2-SelectFolder.tsx
+++ b/src/react/components/KeyGeneratioinFlow/2-SelectFolder.tsx
@@ -9,6 +9,8 @@ type SelectFolderProps = {
   folderError: boolean,
   setFolderErrorMsg: Dispatch<SetStateAction<string>>,
   folderErrorMsg: string,
+  setModalDisplay: Dispatch<SetStateAction<boolean>>,
+  modalDisplay: boolean,
 }
 
 const SelectFolder: FC<SelectFolderProps> = (props): ReactElement => {
@@ -19,6 +21,7 @@ const SelectFolder: FC<SelectFolderProps> = (props): ReactElement => {
       properties: ['openDirectory']
     };
 
+    props.setModalDisplay(true);
     ipcRenderer.invoke('showOpenDialog', options)
       .then((value: OpenDialogReturnValue) => {
         if (value !== undefined && value.filePaths.length > 0) {
@@ -26,6 +29,9 @@ const SelectFolder: FC<SelectFolderProps> = (props): ReactElement => {
         } else {
           props.setFolderError(true);
         }
+      })
+      .finally(() => {
+        props.setModalDisplay(false);
       });
   }
 
@@ -37,7 +43,7 @@ const SelectFolder: FC<SelectFolderProps> = (props): ReactElement => {
         </Typography>
       </Grid>
       <Grid item xs={12}>
-        <Button variant="contained" component="label" onClick={chooseFolder} tabIndex={1}>
+        <Button variant="contained" component="label" onClick={chooseFolder} tabIndex={1} disabled={props.modalDisplay}>
           Browse
         </Button>
       </Grid>

--- a/src/react/components/KeyGenerationWizard.tsx
+++ b/src/react/components/KeyGenerationWizard.tsx
@@ -31,6 +31,7 @@ const KeyGenerationWizard: FC<Props> = (props): ReactElement => {
   const [step, setStep] = useState(0);
   const [folderError, setFolderError] = useState(false);
   const [folderErrorMsg, setFolderErrorMsg] = useState("");
+  const [modalDisplay, setModalDisplay] = useState(false);
   
   const prevLabel = () => {
     switch (step) {
@@ -143,7 +144,7 @@ const KeyGenerationWizard: FC<Props> = (props): ReactElement => {
   const content = () => {
     switch(step) {
       case 0: return (
-        <SelectFolder setFolderPath={props.setFolderPath} folderPath={props.folderPath} setFolderError={setFolderError} folderError={folderError} setFolderErrorMsg={setFolderErrorMsg} folderErrorMsg={folderErrorMsg} />
+        <SelectFolder setFolderPath={props.setFolderPath} folderPath={props.folderPath} setFolderError={setFolderError} folderError={folderError} setFolderErrorMsg={setFolderErrorMsg} folderErrorMsg={folderErrorMsg} modalDisplay={modalDisplay} setModalDisplay={setModalDisplay} />
       );
       case 1: return (
         <CreatingKeys />
@@ -174,7 +175,8 @@ const KeyGenerationWizard: FC<Props> = (props): ReactElement => {
         onNext={nextClicked}
         backLabel={prevLabel()}
         nextLabel={nextLabel()}
-        disableNext={!props.folderPath}
+        disableBack={modalDisplay}
+        disableNext={!props.folderPath || modalDisplay}
         hideBack={step === 1}
         hideNext={step === 1}
       />


### PR DESCRIPTION
To prevent the user from interactive with the wizard and going back when selecting his folder