### PR TITLE
Fix license type to GPL-3.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "description": "GUI key generation tool wrapping the deposit cli.",
   "main": "./build/electron/index.js",
   "author": "Colfax Selby <colfax.selby@gmail.com>",
-  "license": "MIT",
+  "license": "GPL-3.0",
   "devDependencies": {
     "@types/react": "^17.0.14",
     "@types/react-dom": "^17.0.9",


### PR DESCRIPTION
changed manifest listing of `MIT` license to match the GH repo and license file in the repo as `GPL-3.0`
Should fix https://github.com/stake-house/wagyu-key-gen/issues/139