### PR TITLE
Revert "make providing withdrawal creds required"

### DIFF
--- a/src/react/components/KeyConfigurationWizard.tsx
+++ b/src/react/components/KeyConfigurationWizard.tsx
@@ -23,6 +23,8 @@ type Props = {
   setWithdrawalAddress: Dispatch<SetStateAction<string>>,
   password: string,
   setPassword: Dispatch<SetStateAction<string>>,
+  showAdvanced: boolean,
+  setShowAdvanced: Dispatch<SetStateAction<boolean>>
 }
 
 /**
@@ -69,6 +71,7 @@ const KeyConfigurationWizard: FC<Props> = (props): ReactElement => {
         setWithdrawalAddressFormatError(false);
         setPasswordStrengthError(false);
         setStartingIndexError(false);
+        props.setShowAdvanced(false);
         props.setPassword("");
         props.setKeyGenerationStartIndex(props.initialKeyGenerationStartIndex);
         props.setNumberOfKeys(1);
@@ -145,9 +148,13 @@ const KeyConfigurationWizard: FC<Props> = (props): ReactElement => {
       setStartingIndexError(false);
     }
 
-    if (!window.web3Utils.isAddress(props.withdrawalAddress)) {
-      setWithdrawalAddressFormatError(true);
-      isError = true;
+    if (props.withdrawalAddress != "" && props.showAdvanced) {
+      if (!window.web3Utils.isAddress(props.withdrawalAddress)) {
+        setWithdrawalAddressFormatError(true);
+        isError = true;
+      } else {
+        setWithdrawalAddressFormatError(false);
+      }
     } else {
       setWithdrawalAddressFormatError(false);
     }
@@ -184,6 +191,8 @@ const KeyConfigurationWizard: FC<Props> = (props): ReactElement => {
           setWithdrawalAddressFormatError={setWithdrawalAddressFormatError}
           passwordStrengthError={passwordStrengthError}
           startingIndexError={startingIndexError}
+          showAdvanced={props.showAdvanced}
+          setShowAdvanced={props.setShowAdvanced}
           onFinish={validateInputs}
         />
       );

--- a/src/react/components/KeyGeneratioinFlow/0-KeyInputs.tsx
+++ b/src/react/components/KeyGeneratioinFlow/0-KeyInputs.tsx
@@ -18,6 +18,8 @@ type GenerateKeysProps = {
   numberOfKeysError: boolean,
   passwordStrengthError: boolean,
   startingIndexError: boolean,
+  showAdvanced: boolean,
+  setShowAdvanced: Dispatch<SetStateAction<boolean>>,
   onFinish: () => void
 }
 
@@ -39,6 +41,14 @@ const AddressTextField = styled(TextField)`
  * @returns 
  */
 const KeyInputs = (props: GenerateKeysProps) => {
+  
+  const handleToggleShowAdvanced = () => {
+    props.setShowAdvanced(!props.showAdvanced);
+    if (!props.showAdvanced) {
+      props.setWithdrawalAddress("");
+      props.setWithdrawalAddressFormatError(false);
+    }
+  }
 
   const updateNumberOfKeys = (e: React.ChangeEvent<HTMLInputElement>) => {
     const num = parseInt(e.target.value);
@@ -114,25 +124,33 @@ const KeyInputs = (props: GenerateKeysProps) => {
         </Grid>
       </Grid>
       <Grid item>
-        <Grid container item direction="row" justifyContent="center" alignItems="center" spacing={2} xs={12}>
-          <Grid item>
-            <Tooltip title={tooltips.ETH1_WITHDRAW_ADDRESS}>
-              <AddressTextField
-                id="eth1-withdraw-address"
-                label="Ethereum Withdrawal Address"
-                variant="outlined"
-                value={props.withdrawalAddress}
-                onChange={updateEth1WithdrawAddress}
-                error={props.withdrawalAddressFormatError}
-                helperText={ props.withdrawalAddressFormatError ? errors.ADDRESS_FORMAT_ERROR : ""}
-              />
-            </Tooltip>
-            <Typography variant="body1">
-              Please ensure that you have control over this address.
-            </Typography>
-          </Grid>
-        </Grid>
+        <FormControlLabel
+          control={<Switch checked={props.showAdvanced} onChange={handleToggleShowAdvanced} color="default" size="small" />}
+          label="Use Advanced Inputs"
+        />
       </Grid>
+      <Grid item>
+          <Fade in={props.showAdvanced} >
+            <Grid container item direction="row" justifyContent="center" alignItems="center" spacing={2} xs={12}>
+              <Grid item>
+                <Tooltip title={tooltips.ETH1_WITHDRAW_ADDRESS}>
+                  <AddressTextField
+                    id="eth1-withdraw-address"
+                    label="Ethereum Withdrawal Address (Optional)"
+                    variant="outlined"
+                    value={props.withdrawalAddress}
+                    onChange={updateEth1WithdrawAddress}
+                    error={props.withdrawalAddressFormatError}
+                    helperText={ props.withdrawalAddressFormatError ? errors.ADDRESS_FORMAT_ERROR : ""}
+                  />
+                </Tooltip>
+                <Typography variant="body1">
+                  Please ensure that you have control over this address.
+                </Typography>
+              </Grid>
+            </Grid>
+          </Fade>
+        </Grid>
     </Grid>
   );
 }

--- a/src/react/constants.ts
+++ b/src/react/constants.ts
@@ -20,7 +20,7 @@ export const tooltips = {
 	NUMBER_OF_KEYS: "Enter how many new validator keys you'd like to create.",
 	PASSWORD: "Pick a strong password (at least 8 characters) that will be used to protect your keys.",
 	STARTING_INDEX: "Each key is created sequentially, so we need to know how many you've created with this Secret Recovery Phrase in the past in order to create some new ones for you.",
-	ETH1_WITHDRAW_ADDRESS: "An Ethereum address for the withdrawal credentials.",
+	ETH1_WITHDRAW_ADDRESS: "An optional Ethereum address for the withdrawal credentials.",
 };
 
 export const stepLabels = {

--- a/src/react/pages/MainWizard.tsx
+++ b/src/react/pages/MainWizard.tsx
@@ -65,6 +65,7 @@ const Wizard: FC<WizardProps> = (props): ReactElement => {
   const [withdrawalAddress, setWithdrawalAddress] = useState("");
   const [password, setPassword] = useState("");
   const [folderPath, setFolderPath] = useState("");
+  const [showAdvanced, setShowAdvanced] = useState(false);
 
   const stepSequence = stepSequenceMap[stepSequenceKey];
   const activeStepKey = stepSequence[activeStepIndex];
@@ -136,6 +137,8 @@ const Wizard: FC<WizardProps> = (props): ReactElement => {
             setWithdrawalAddress={setWithdrawalAddress}
             password={password}
             setPassword={setPassword}
+            showAdvanced={showAdvanced}
+            setShowAdvanced={setShowAdvanced}
           />
         );
         case StepKey.KeyGeneration:


### PR DESCRIPTION
## Description
- Related to https://github.com/stake-house/wagyu-key-gen/issues/155
- Reverts PR #153 changes

Does not update UI to improve UX, simply reverts the previous changes to bring back the option for users to opt-in-or-out of withdrawals