### PR TITLE
Improving wording of regenerate flow to help with available actions

### DIFF
--- a/src/react/components/ReuseMnemonicActionPicker.tsx
+++ b/src/react/components/ReuseMnemonicActionPicker.tsx
@@ -39,7 +39,7 @@ type ReuseMnemonicActionPickerProps = {
 /**
  * This is the reuse mnemonic action picker modal component where the user selects which action they want
  * to perform after reusing their mnemonic.
- * 
+ *
  * @param props.handleCloseReuseMnemonicModal function to handle closing the reuse mnemonic action modal
  * @param props.setReuseMnemonicAction update the selected reuse mnemonic action
  * @param props.reuseMnemonicAction the selected reuse mnemonic action
@@ -70,7 +70,7 @@ export const ReuseMnemonicActionPicker = (props: ReuseMnemonicActionPickerProps)
         <OptionsGrid container spacing={2} direction="column">
           <Grid item>
             <Button variant="contained" color="primary" onClick={handleSelectRegenerateKeys}>
-              Regenerate your validator keys
+              Regenerate or create new validator keys
             </Button>
           </Grid>
           <Grid item>

--- a/src/react/constants.ts
+++ b/src/react/constants.ts
@@ -23,7 +23,7 @@ export const errors = {
 export const MNEMONIC_LENGTH = 24;
 
 export const tooltips = {
-	IMPORT_MNEMONIC: "If you've already created a Secret Recovery Phrase, you can create more keys from it by importing it here.",
+	IMPORT_MNEMONIC: "If you've already created a Secret Recovery Phrase, you can use it to regenerate your original keys, create more keys, or generate a BLS to execution change by importing the phrase here.",
 	NUMBER_OF_KEYS: "Enter how many new validator keys you'd like to create.",
 	PASSWORD: "Pick a strong password (at least 8 characters) that will be used to protect your keys.",
 	STARTING_INDEX: "Each key is created sequentially, so we need to know how many you've created with this Secret Recovery Phrase in the past in order to create some new ones for you.",


### PR DESCRIPTION
User on discord was displeased with the inconsistency between the Import tooltip and the regenerate button text as it was not descriptive of what was possible.

Updated to be more descriptive.