### PR TITLE
Allowing non-24 word mnemonics

### DIFF
--- a/src/react/components/MnemonicImport.tsx
+++ b/src/react/components/MnemonicImport.tsx
@@ -2,7 +2,7 @@ import { Grid, TextField, Typography } from "@material-ui/core";
 import React, { FC, ReactElement, useState, Dispatch, SetStateAction } from "react";
 import styled from "styled-components";
 import ValidatingMnemonic from './MnemonicImportFlow/1-ValidatingMnemonic';
-import { errors, MNEMONIC_ERROR_SEARCH, MINIMUM_MNEMONIC_LENGTH } from "../constants";
+import { errors, MNEMONIC_ERROR_SEARCH, VALID_MNEMONIC_LENGTHS } from "../constants";
 import StepNavigation from './StepNavigation';
 import { cleanMnemonic } from '../helpers';
 
@@ -44,7 +44,7 @@ const MnemonicImport: FC<Props> = (props): ReactElement => {
 
     const mnemonicArray = cleanedMnemonic.split(" ");
 
-    if (mnemonicArray.length < MINIMUM_MNEMONIC_LENGTH) {
+    if (!VALID_MNEMONIC_LENGTHS.includes(mnemonicArray.length)) {
       setMnemonicError(true);
       setMnemonicErrorMsg(errors.MNEMONIC_LENGTH_ERROR);
     } else {

--- a/src/react/components/MnemonicImport.tsx
+++ b/src/react/components/MnemonicImport.tsx
@@ -2,7 +2,7 @@ import { Grid, TextField, Typography } from "@material-ui/core";
 import React, { FC, ReactElement, useState, Dispatch, SetStateAction } from "react";
 import styled from "styled-components";
 import ValidatingMnemonic from './MnemonicImportFlow/1-ValidatingMnemonic';
-import { errors, MNEMONIC_LENGTH } from "../constants";
+import { errors, MNEMONIC_ERROR_SEARCH, MINIMUM_MNEMONIC_LENGTH } from "../constants";
 import StepNavigation from './StepNavigation';
 import { cleanMnemonic } from '../helpers';
 
@@ -20,7 +20,7 @@ type Props = {
 
 /**
  * This is the Mnemonic Import flow
- * 
+ *
  * @param props data and functions passed in for usage, the names are self documenting
  * @returns mnemonic import components to render
  */
@@ -44,11 +44,10 @@ const MnemonicImport: FC<Props> = (props): ReactElement => {
 
     const mnemonicArray = cleanedMnemonic.split(" ");
 
-    if (mnemonicArray.length != MNEMONIC_LENGTH) {
+    if (mnemonicArray.length < MINIMUM_MNEMONIC_LENGTH) {
       setMnemonicError(true);
-      setMnemonicErrorMsg(errors.MNEMONIC_FORMAT);
+      setMnemonicErrorMsg(errors.MNEMONIC_LENGTH_ERROR);
     } else {
-
       setStep(step + 1);
 
       window.eth2Deposit.validateMnemonic(cleanedMnemonic).then(() => {
@@ -57,9 +56,12 @@ const MnemonicImport: FC<Props> = (props): ReactElement => {
         setStep(0);
         const errorMsg = ('stderr' in error) ? error.stderr : error.message;
         setMnemonicError(true);
-        setMnemonicErrorMsg(errorMsg);
+        if (errorMsg.indexOf(MNEMONIC_ERROR_SEARCH) >= 0) {
+          setMnemonicErrorMsg(errors.INVALID_MNEMONIC_ERROR);
+        } else {
+          setMnemonicErrorMsg(errorMsg);
+        }
       })
-
     }
   }
 

--- a/src/react/constants.ts
+++ b/src/react/constants.ts
@@ -1,7 +1,10 @@
 import { StepKey } from './types';
 
+export const MNEMONIC_ERROR_SEARCH = "That is not a valid mnemonic";
+export const VALID_MNEMONIC_LENGTHS = [12, 15, 18, 21, 24];
+
 export const errors = {
-	MNEMONIC_LENGTH_ERROR: "The Secret Recovery Phrase must be at least 12 words in length.",
+	MNEMONIC_LENGTH_ERROR: `The Secret Recovery Phrase must be ${VALID_MNEMONIC_LENGTHS.slice(0, -1).join(", ")}, or ${VALID_MNEMONIC_LENGTHS.slice(-1)} words in length. Please verify each word and try again.`,
 	INVALID_MNEMONIC_ERROR: "The Secret Recovery Phrase provided is invalid. Please double check each word for any spelling errors.",
 	MNEMONICS_DONT_MATCH: "The Secret Recovery Phrase you entered does not match what was given to you. Please try again.",
 	NUMBER_OF_KEYS: "Please input a number between 1 and 1000.",
@@ -20,9 +23,6 @@ export const errors = {
 	FOLDER_DOES_NOT_EXISTS: "Folder does not exist. Select an existing folder.",
 	FOLDER_IS_NOT_WRITABLE: "Cannot write in this folder. Select a folder in which you have write permission.",
 };
-
-export const MNEMONIC_ERROR_SEARCH = "That is not a valid mnemonic";
-export const MINIMUM_MNEMONIC_LENGTH = 12;
 
 export const tooltips = {
 	IMPORT_MNEMONIC: "If you've already created a Secret Recovery Phrase, you can use it to regenerate your original keys, create more keys, or generate a BLS to execution change by importing the phrase here.",

--- a/src/react/constants.ts
+++ b/src/react/constants.ts
@@ -1,8 +1,8 @@
 import { StepKey } from './types';
 
 export const errors = {
-	MNEMONIC_LENGTH_ERROR: "Mnemonics must be at least 12 words in length.",
-	INVALID_MNEMONIC_ERROR: "The mnemonic provided is invalid. Please double check each word for any spelling errors.",
+	MNEMONIC_LENGTH_ERROR: "The Secret Recovery Phrase must be at least 12 words in length.",
+	INVALID_MNEMONIC_ERROR: "The Secret Recovery Phrase provided is invalid. Please double check each word for any spelling errors.",
 	MNEMONICS_DONT_MATCH: "The Secret Recovery Phrase you entered does not match what was given to you. Please try again.",
 	NUMBER_OF_KEYS: "Please input a number between 1 and 1000.",
 	ADDRESS_FORMAT_ERROR: "Please enter a valid Ethereum address.",

--- a/src/react/constants.ts
+++ b/src/react/constants.ts
@@ -1,7 +1,8 @@
 import { StepKey } from './types';
 
 export const errors = {
-	MNEMONIC_FORMAT: "Invalid format. Your Secret Recovery Phrase should be a 24 word list.",
+	MNEMONIC_LENGTH_ERROR: "Mnemonics must be at least 12 words in length.",
+	INVALID_MNEMONIC_ERROR: "The mnemonic provided is invalid. Please double check each word for any spelling errors.",
 	MNEMONICS_DONT_MATCH: "The Secret Recovery Phrase you entered does not match what was given to you. Please try again.",
 	NUMBER_OF_KEYS: "Please input a number between 1 and 1000.",
 	ADDRESS_FORMAT_ERROR: "Please enter a valid Ethereum address.",
@@ -20,7 +21,8 @@ export const errors = {
 	FOLDER_IS_NOT_WRITABLE: "Cannot write in this folder. Select a folder in which you have write permission.",
 };
 
-export const MNEMONIC_LENGTH = 24;
+export const MNEMONIC_ERROR_SEARCH = "That is not a valid mnemonic";
+export const MINIMUM_MNEMONIC_LENGTH = 12;
 
 export const tooltips = {
 	IMPORT_MNEMONIC: "If you've already created a Secret Recovery Phrase, you can use it to regenerate your original keys, create more keys, or generate a BLS to execution change by importing the phrase here.",


### PR DESCRIPTION
Updating the Existing Mnemonic flow to remove the 24 word requirement and change to a minimum of 12 words. 

The CLI seems to support any valid mnemonic above and including 12 words, 9 words fail as an example. We can introduce a similar restriction on our end and then depend on the CLI for anything beyond to do the verification.

Speaking of verification, I noticed the returned error message was pretty technical in response and some users may be confused. I created a search string of "That is not a valid mnemonic" that is always returned with the error message and, if so, will display a more friendly error message encouraging the user to double check their input.

fixes #164 