### PR TITLE
WIP: Adding support for amount and compounding parameters

### DIFF
--- a/src/electron/renderer.d.ts
+++ b/src/electron/renderer.d.ts
@@ -33,8 +33,8 @@ export interface IElectronAPI {
 export interface IEth2DepositAPI {
   createMnemonic: (language: string) => Promise<string>,
   generateBLSChange: (folder: string, chain: string, mnemonic: string, index: number, indices: string, withdrawal_credentials: string, execution_address: string) => Promise<void>,
-  generateKeys: (mnemonic: string, index: number, count: number, network: string,
-    password: string, eth1_withdrawal_address: string, folder: string) => Promise<void>,
+  generateKeys: (mnemonic: string, index: number, amount: number, count: number, network: string,
+    password: string, eth1_withdrawal_address: string, compounding: boolean, folder: string) => Promise<void>,
   validateBLSCredentials: (chain: string, mnemonic: string, index: number, withdrawal_credentials: string) => Promise<void>,
   validateMnemonic: (mnemonic: string) => Promise<void>,
 }

--- a/src/react/KeyCreationContext.tsx
+++ b/src/react/KeyCreationContext.tsx
@@ -9,10 +9,14 @@ interface KeyCreationContextType {
   setMnemonic: Dispatch<SetStateAction<string>>;
   numberOfKeys: number;
   setNumberOfKeys: Dispatch<SetStateAction<number>>;
+  amount: number;
+  setAmount: Dispatch<SetStateAction<number>>;
   password: string;
   setPassword: Dispatch<SetStateAction<string>>;
   withdrawalAddress: string;
   setWithdrawalAddress: Dispatch<SetStateAction<string>>;
+  compounding: boolean;
+  setCompounding: Dispatch<SetStateAction<boolean>>;
 }
 
 export const KeyCreationContext = createContext<KeyCreationContextType>({
@@ -24,10 +28,14 @@ export const KeyCreationContext = createContext<KeyCreationContextType>({
   setMnemonic: () => {},
   numberOfKeys: 1,
   setNumberOfKeys: () => {},
+  amount: 32,
+  setAmount: () => {},
   password: "",
   setPassword: () => {},
   withdrawalAddress: "",
   setWithdrawalAddress: () => {},
+  compounding: false,
+  setCompounding: () => {},
 });
 
 /**
@@ -38,8 +46,10 @@ const KeyCreationContextWrapper = ({ children }: { children: React.ReactNode}) =
   const [index, setIndex] = useState<number>(0);
   const [mnemonic, setMnemonic] = useState<string>("");
   const [numberOfKeys, setNumberOfKeys] = useState<number>(1);
+  const [amount, setAmount] = useState<number>(32);
   const [password, setPassword] = useState<string>("");
   const [withdrawalAddress, setWithdrawalAddress] = useState<string>("");
+  const [compounding, setCompounding] = useState<boolean>(false);
 
   return (
     <KeyCreationContext.Provider value={{
@@ -51,10 +61,14 @@ const KeyCreationContextWrapper = ({ children }: { children: React.ReactNode}) =
       setMnemonic,
       numberOfKeys,
       setNumberOfKeys,
+      amount,
+      setAmount,
       password,
       setPassword,
       withdrawalAddress,
       setWithdrawalAddress,
+      compounding,
+      setCompounding,
     }}>
       {children}
     </KeyCreationContext.Provider>

--- a/src/react/constants.ts
+++ b/src/react/constants.ts
@@ -2,12 +2,14 @@ import { StepKey } from './types';
 
 export const MNEMONIC_ERROR_SEARCH = "That is not a valid mnemonic";
 export const VALID_MNEMONIC_LENGTHS = [12, 15, 18, 21, 24];
+export const ETH_TO_GWEI = 10 ** 9;
 
 export const errors = {
 	MNEMONIC_LENGTH_ERROR: `The Secret Recovery Phrase must be ${VALID_MNEMONIC_LENGTHS.slice(0, -1).join(", ")}, or ${VALID_MNEMONIC_LENGTHS.slice(-1)} words in length. Please verify each word and try again.`,
 	INVALID_MNEMONIC_ERROR: "The Secret Recovery Phrase provided is invalid. Please double check each word for any spelling errors.",
 	MNEMONICS_DONT_MATCH: "The Secret Recovery Phrase you entered does not match what was given to you. Please try again.",
 	NUMBER_OF_KEYS: "Please input a number between 1 and 1000.",
+  DEPOSIT_AMOUNT: "Amount must be between 1 and 2048.",
 	ADDRESS_FORMAT_ERROR: "Please enter a valid Ethereum address.",
 	WITHDRAW_ADDRESS_REQUIRED: "Please enter an Ethereum address.",
 	PASSWORD_STRENGTH: "Password must be at least 12 characters.",
@@ -28,6 +30,7 @@ export const errors = {
 export const tooltips = {
 	IMPORT_MNEMONIC: "If you've already created a Secret Recovery Phrase, you can use it to regenerate your original keys, create more keys, or generate a BLS to execution change by importing the phrase here.",
 	NUMBER_OF_KEYS: "Enter how many new validator keys you'd like to create.",
+  AMOUNT: "Enter the amount you would like to deposit for each validator. This value must be between 1 and 2048 and can not have greater precision than 1 gwei. You must have withdrawal credentials defined and set \"compounding\".",
 	PASSWORD: "Pick a strong password (at least 12 characters) that will be used to protect your keys.",
 	STARTING_INDEX: "Each key is created sequentially, so we need to know how many you've created with this Secret Recovery Phrase in the past in order to create some new ones for you.",
 	ETH1_WITHDRAW_ADDRESS: "An optional Ethereum address for the withdrawal credentials.",

--- a/src/react/pages/CreateValidatorKeys.tsx
+++ b/src/react/pages/CreateValidatorKeys.tsx
@@ -5,7 +5,12 @@ import { Button, Typography } from "@mui/material";
 import FolderSelector from "../components/FolderSelector";
 import Loader from "../components/Loader";
 import WizardWrapper from "../components/WizardWrapper";
-import { CreateMnemonicFlow, ExistingMnemonicFlow, paths } from "../constants";
+import {
+  CreateMnemonicFlow,
+  ETH_TO_GWEI,
+  ExistingMnemonicFlow,
+  paths,
+} from "../constants";
 import { GlobalContext } from "../GlobalContext";
 import { KeyCreationContext } from "../KeyCreationContext";
 
@@ -16,11 +21,13 @@ import { KeyCreationContext } from "../KeyCreationContext";
 const CreateValidatorKeys = () => {
   const {
     setFolderLocation,
+    amount,
     index,
     numberOfKeys,
     mnemonic,
     password,
     withdrawalAddress,
+    compounding,
   } = useContext(KeyCreationContext);
   const { network } = useContext(GlobalContext);
   const history = useHistory();
@@ -53,13 +60,18 @@ const CreateValidatorKeys = () => {
       appendedWithdrawalAddress = "0x" + withdrawalAddress;
     }
 
+    // Convert user provided amount to integer representation of gwei
+    const gweiAmount = parseInt((amount * ETH_TO_GWEI).toString());
+
     window.eth2Deposit.generateKeys(
       mnemonic,
       index,
+      gweiAmount,
       numberOfKeys,
       network,
       password,
       appendedWithdrawalAddress,
+      compounding,
       selectedFolder,
     ).then(() => {
       setFolderLocation(selectedFolder);

--- a/src/scripts/stakingdeposit_proxy.py
+++ b/src/scripts/stakingdeposit_proxy.py
@@ -94,14 +94,14 @@ def generate_bls_to_execution_change(
     """
     if not os.path.exists(folder):
         os.mkdir(folder)
-    
+
     eth1_withdrawal_address = execution_address
     if not is_hex_address(eth1_withdrawal_address):
         raise ValueError("The given withdrawal address is not in hexadecimal encoded form.")
 
     eth1_withdrawal_address = to_normalized_address(eth1_withdrawal_address)
     execution_address = eth1_withdrawal_address
-    
+
     # Get chain setting
     chain_setting = get_chain_setting(chain)
 
@@ -124,7 +124,7 @@ def generate_bls_to_execution_change(
         raise ValueError(
             f"The number of keys ({num_keys}) doesn't equal to the corresponding deposit amounts ({len(amounts)})."
         )
-    
+
     compounding = False
     use_pbkdf2 = False
 
@@ -304,6 +304,7 @@ def generate_keys(args):
             - wordlist: path to the word lists directory
             - mnemonic: mnemonic to be used as the seed for generating the keys
             - index: index of the first validator's keys you wish to generate
+            - amount: deposit amount for each validator
             - count: number of signing keys you want to generate
             - folder: folder path for the resulting keystore(s) and deposit(s) files
             - network: network setting for the signing domain, possible values are 'mainnet',
@@ -311,8 +312,10 @@ def generate_keys(args):
             - password: password that will protect the resulting keystore(s)
             - eth1_withdrawal_address: (Optional) eth1 address that will be used to create the
                                        withdrawal credentials
+            - compounding: (Optional) if the user wants compounding (0x02) credentials. Requires
+                                       withdrawal address to be defined
     """
-    
+
     eth1_withdrawal_address = None
     if args.eth1_withdrawal_address:
         eth1_withdrawal_address = args.eth1_withdrawal_address
@@ -323,7 +326,7 @@ def generate_keys(args):
 
     mnemonic = validate_mnemonic(args.mnemonic, args.wordlist)
     mnemonic_password = ''
-    amounts = [MAX_DEPOSIT_AMOUNT] * args.count
+    amounts = [args.amount] * args.count
     folder = args.folder
     chain_setting = get_chain_setting(args.network)
     if not os.path.exists(folder):
@@ -340,9 +343,8 @@ def generate_keys(args):
         )
 
     timestamp = time.time()
-    compounding = False
     use_pbkdf2 = False
-    
+
     key_indices = range(start_index, start_index + num_keys)
 
     credentials: list[Credential] = []
@@ -353,7 +355,7 @@ def generate_keys(args):
         'amount': amounts[index - start_index],
         'chain_setting': chain_setting,
         'hex_withdrawal_address': hex_withdrawal_address,
-        'compounding': compounding,
+        'compounding': args.compounding,
         'use_pbkdf2': use_pbkdf2,
     } for index in key_indices]
 
@@ -390,7 +392,7 @@ def generate_keys(args):
         'credential': credential,
         'keystore_filefolder': fileholder,
         'password': password,
-    } for credential, fileholder in zip(credentials.credentials, keystore_filefolders)]
+    } for credential, fileholder in items]
 
     with concurrent.futures.ProcessPoolExecutor() as executor:
         for valid_keystore in executor.map(_keystore_verifier, executor_kwargs):
@@ -467,7 +469,7 @@ def main():
     main_parser = argparse.ArgumentParser()
 
     subparsers = main_parser.add_subparsers(title="subcommands")
-    
+
     create_parser = subparsers.add_parser("create_mnemonic")
     create_parser.add_argument("wordlist", help="Path to word list directory", type=str)
     create_parser.add_argument("--language", help="Language", type=str)
@@ -477,11 +479,13 @@ def main():
     generate_parser.add_argument("wordlist", help="Path to word list directory", type=str)
     generate_parser.add_argument("mnemonic", help="Mnemonic", type=str)
     generate_parser.add_argument("index", help="Validator start index", type=int)
+    generate_parser.add_argument("amount", help="Validator deposit amount", type=int)
     generate_parser.add_argument("count", help="Validator count", type=int)
     generate_parser.add_argument("folder", help="Where to put the deposit data and keystore files", type=str)
     generate_parser.add_argument("network", help="For which network to create these keys for", type=str)
     generate_parser.add_argument("password", help="Password for the keystore files", type=str)
     generate_parser.add_argument("--eth1_withdrawal_address", help="Optional eth1 withdrawal address", type=str)
+    generate_parser.add_argument("--compounding", action="store_true", help="Optional compounding argument")
     generate_parser.set_defaults(func=parse_generate_keys)
 
     validate_parser = subparsers.add_parser("validate_mnemonic")


### PR DESCRIPTION
Adding support for `amount` and `compounding` when a user is generating or regenerating keys.

`amount` can only be changed if `compounding` flag is set and `compounding` can only be set if a withdrawal address is defined.

This is WIP for two reasons:
- Improve messaging with errors and tooltips
- Need to test edge cases
- Given how the inputs are disabled, I want to play around changing the order of fields. I'm thinking
```
Address - Compounding - Amount
NumKeys - {StartIndex} - Password
```
But need to play around with it

I did test the output and compared with deposit-cli and got identical results.