### PR TITLE
Replace the Goerli testnet choice with the Mekong one

### DIFF
--- a/src/electron/Eth2Deposit.ts
+++ b/src/electron/Eth2Deposit.ts
@@ -257,7 +257,7 @@ const validateMnemonic = async (
  * from the stakingdeposit_proxy application.
  *
  * @param chain The network setting for the signing domain. Possible values are `mainnet`,
- *              `goerli`, `holesky`.
+ *              `mekong`, `holesky`.
  * @param mnemonic The mnemonic from which the BLS credentials are derived.
  * @param index The index of the first validator's keys.
  * @param withdrawal_credentials A list of the old BLS withdrawal credentials of the given validator(s), comma separated.
@@ -300,7 +300,7 @@ const validateBLSCredentials = async (
  *
  * @param folder The folder path for the resulting BTEC file.
  * @param chain The network setting for the signing domain. Possible values are `mainnet`,
- *              `goerli`, `holesky`.
+ *              `mekong`, `holesky`.
  * @param mnemonic The mnemonic to be used as the seed for generating the BTEC.
  * @param index The index of the first validator's keys.
  * @param indices The validator index number(s) as identified on the beacon chain (comma separated).

--- a/src/react/modals/NetworkPickerModal.tsx
+++ b/src/react/modals/NetworkPickerModal.tsx
@@ -60,7 +60,7 @@ const NetworkPickerModal = ({onClose, showModal}: NetworkPickerModalParams) => {
             <Divider />
             <Typography className="tw-text-xl tw-mt-5 tw-mb-4">Testnets</Typography>
             <FormControlLabel value={Network.HOLESKY} control={<Radio />} label={Network.HOLESKY} />
-            <FormControlLabel value={Network.GOERLI} control={<Radio />} label={Network.GOERLI} />
+            <FormControlLabel value={Network.MEKONG} control={<Radio />} label={Network.MEKONG} />
           </RadioGroup>
 
           <Button

--- a/src/react/types.ts
+++ b/src/react/types.ts
@@ -22,6 +22,6 @@ export enum ReuseMnemonicAction {
 
 export enum Network {
   MAINNET = "Mainnet",
-  GOERLI = "Goerli",
+  MEKONG = "Mekong",
   HOLESKY = "Holesky"
 }

--- a/src/scripts/stakingdeposit_proxy.py
+++ b/src/scripts/stakingdeposit_proxy.py
@@ -85,7 +85,7 @@ def generate_bls_to_execution_change(
     Keyword arguments:
     folder -- folder path for the resulting bls to execution change files
     chain -- chain setting for the signing domain, possible values are 'mainnet',
-                'goerli', 'holesky'
+                'mekong', 'holesky'
     mnemonic -- mnemonic to be used as the seed for generating the keys
     validator_start_index -- index position for the keys to start generating withdrawal credentials
     validator_indices -- a list of the chosen validator index number(s) as identified on the beacon chain
@@ -206,7 +206,7 @@ def validate_bls_credentials(
 
     Keyword arguments:
     chain -- chain setting for the signing domain, possible values are 'mainnet',
-                'goerli', 'holesky'
+                'mekong', 'holesky'
     mnemonic -- mnemonic to be used as the seed for generating the keys
     validator_start_index -- index position for the keys to start generating withdrawal credentials
     bls_withdrawal_credentials_list -- a list of the old BLS withdrawal credentials of the given validator(s)


### PR DESCRIPTION
The removal of the Goerli testnet is long overdue. This PR replaces it with the Mekong one which is still online.